### PR TITLE
fix: sshpass new version 1.10

### DIFF
--- a/Library/Formula/sshpass.rb
+++ b/Library/Formula/sshpass.rb
@@ -1,12 +1,12 @@
 require 'formula'
 
 class Sshpass < Formula
-  url 'http://sourceforge.net/projects/sshpass/files/sshpass/1.06/sshpass-1.06.tar.gz'
+  url 'https://sourceforge.net/projects/sshpass/files/sshpass/1.10/sshpass-1.10.tar.gz'
   homepage 'http://sourceforge.net/projects/sshpass'
-  sha256 'c6324fcee608b99a58f9870157dfa754837f8c48be3df0f5e2f3accf145dee60'
+  sha256 'ad1106c203cbb56185ca3bad8c6ccafca3b4064696194da879f81c8d7bdfeeda'
 
   def install
-    system "./configure", "--disable-debug", "--disable-dependency-tracking",
+    system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make install"
   end


### PR DESCRIPTION
* checked on macOS Ventura Version 13.5.2 (22G91), Chip Apple M1 Pro